### PR TITLE
Fix undisplayed charts in tabs

### DIFF
--- a/index.html
+++ b/index.html
@@ -306,58 +306,58 @@
 						<h2>Comparaison nutritionnelle</h2>
 						<p>Quels apports pour quel produit ?</p>
 					</header>
-                    <p>Combien de biscuits faut-il manger pour consommer <b>autant de sucre</b> que dans une cuillère à café de pâte à tartiner ? 
-                        Combien de verres de jus d'orange faut-il boire pour récupérer <b>autant d'énergie</b> que dans une dose de cette même pâte à tartiner ? 
+                    <p>Combien de biscuits faut-il manger pour consommer <b>autant de sucre</b> que dans une cuillère à café de pâte à tartiner ?
+                        Combien de verres de jus d'orange faut-il boire pour récupérer <b>autant d'énergie</b> que dans une dose de cette même pâte à tartiner ?
                         Combien de yaourts faut-il manger pour stocker <b>autant de graisses</b> ?</p>
                     <h3> Cliquez sur le type de marque que vous souhaitez et découvrez-le !</h3>
-                <div>   
-                <ul class="nav nav-pills nav-justified">
+                <div>
+                <ul class="nav nav-pills nav-justified" id="compare-tabs">
                 <li class="active"><a data-toggle="pill" href="#leader" class="block">Marques leaders</a></li>
                 <li><a data-toggle="pill" href="#distributeur" class="block"  >Marques distributeurs</a></li>
                 <li><a data-toggle="pill" href="#bio" class="block">Marques bio</a></li>
                 <li><a data-toggle="pill" href="#premierprix" class="block">Marques premier prix</a></li>
                 </ul>
                        <p></p>
-                       <p>Un biscuit apporte moins d'énergie, de graisses et de sucres qu'une dose de pâte à tartiner ou qu'un yaourt. 
+                       <p>Un biscuit apporte moins d'énergie, de graisses et de sucres qu'une dose de pâte à tartiner ou qu'un yaourt.
                           Ainsi, il faut manger <b>cinq biscuits</b> pour consommer autant de sucre que dans une cuillère à café de pâte à tartiner !
                           Les jus d'orange contiennent <b>très peu de graisses</b> : un verre est 15 fois moins gras qu'un biscuit.</p>
                        <p>Il ne faut pas oublier que la <b>pâte à tartiner est le plus gras et le plus sucré</b> des aliments du goûter et
-                          qu'à quantité égale consommée, un biscuit reste <b>plus gras et plus sucré</b> qu'un yaourt ou 
-                          qu'un verre de jus d'orange car les biscuits sont de plus petites portions.  </p> 
+                          qu'à quantité égale consommée, un biscuit reste <b>plus gras et plus sucré</b> qu'un yaourt ou
+                          qu'un verre de jus d'orange car les biscuits sont de plus petites portions.  </p>
                 <div class="tab-content">
                 <div id="leader" class="tab-pane fade in active">
                     <iframe width="100%" style="height:180px;" scrolling="no" class="data-wrapper-chart" src="chart2/data-wrapper-DG-2.html" ></iframe>
-                    <p> Une dose de <b>Nutella</b> apporte <b>autant de sucres et d'énergie</b> qu'un <b>yaourt Danone, Nestle ou Yoplait</b> et autant 
+                    <p> Une dose de <b>Nutella</b> apporte <b>autant de sucres et d'énergie</b> qu'un <b>yaourt Danone, Nestle ou Yoplait</b> et autant
                         de graisses que 3 de ces yaourts !
-                        Il faut boire un verre de jus d'orange d'une marque leader pour accumuler <b>autant d'énergie</b> qu'en mangeant un biscuit 
+                        Il faut boire un verre de jus d'orange d'une marque leader pour accumuler <b>autant d'énergie</b> qu'en mangeant un biscuit
                         BN ou Lu et un paquet de <b>4 de ces biscuits</b> contient <b>autant de graisses</b> que <b>trois yaourts</b>.   </p>
                 </div>
-                
+
                 <div id="distributeur" class="tab-pane fade">
-                    <iframe width="100%" style="height:180px;" scrolling="no" class="data-wrapper-chart" src="chart1/data-wrapper-DG-1.html" ></iframe>
+                    <iframe width="100%" style="height:180px;" scrolling="no" class="data-wrapper-chart" data-src="chart1/data-wrapper-DG-1.html" ></iframe>
                     <p> Pour accumuler autant d'énergie qu'en mangeant <b>une petite cuillère</b> de pâte à tartiner il faut : boire <b>4</b> verres
-                        de jus d'orange, grignoter <b>3</b> biscuits ou manger <b>2</b> yaourts de marque distributeur! De plus, en termes de graisses, une 
-                        dose de leurs pâtes à tartiner contient <b>3 fois la quantité de graisses</b> d'un yaourt et un verre de jus d'orange apporte 
-                        <b>autant de sucres</b> qu'un de leurs yaourts.   </p>              
+                        de jus d'orange, grignoter <b>3</b> biscuits ou manger <b>2</b> yaourts de marque distributeur! De plus, en termes de graisses, une
+                        dose de leurs pâtes à tartiner contient <b>3 fois la quantité de graisses</b> d'un yaourt et un verre de jus d'orange apporte
+                        <b>autant de sucres</b> qu'un de leurs yaourts.   </p>
                 </div>
                 <div id="bio" class="tab-pane fade">
-                     <iframe width="100%" style="height:180px;" scrolling="no" class="data-wrapper-chart" src="chart3/data-wrapper-DG-3.html" ></iframe> 
-                    <p> Les marques bio <b>se distinguent particulièrement</b> des autres marques. En effet, une dose de pâte à tartiner bio contient 
+                     <iframe width="100%" style="height:180px;" scrolling="no" class="data-wrapper-chart" data-src="chart3/data-wrapper-DG-3.html" ></iframe>
+                    <p> Les marques bio <b>se distinguent particulièrement</b> des autres marques. En effet, une dose de pâte à tartiner bio contient
                         autant de sucres qu'<b>un seul verre de jus d'orange bio</b> et non deux verres. De plus, il faut <b>4 biscuits bio et non 3</b>
-                        pour récupérer autant d'énergie qu'avec une cuillère à café de pâte à tartiner bio aux noisettes. En termes de graisses 
+                        pour récupérer autant d'énergie qu'avec une cuillère à café de pâte à tartiner bio aux noisettes. En termes de graisses
                         absorbées, c'est 5 biscuits et non 4 qui sont équivalents à cette quantité de pâte à tartiner. Ceci s'explique en partie par le fait
-                        que les pâtes à tartiner bio soient <b>plus grasses que la moyenne</b>. Finalement, les jus d'orange bio sont <b>moins gras</b> 
-                        que les autres. </p>                
+                        que les pâtes à tartiner bio soient <b>plus grasses que la moyenne</b>. Finalement, les jus d'orange bio sont <b>moins gras</b>
+                        que les autres. </p>
                 </div>
-                
+
                  <div id="premierprix" class="tab-pane fade">
-                     <iframe width="100%" style="height:180px;" scrolling="no" class="data-wrapper-chart" src="chart4/data-wrapper-DG-4.html" ></iframe>
-                    <p> Il est <b>équivalent</b> de manger un <b>yaourt</b> premier prix ou une <b>dose de pâte à tartiner</b> ! Un biscuit premier 
+                     <iframe width="100%" style="height:180px;" scrolling="no" class="data-wrapper-chart" data-src="chart4/data-wrapper-DG-4.html" ></iframe>
+                    <p> Il est <b>équivalent</b> de manger un <b>yaourt</b> premier prix ou une <b>dose de pâte à tartiner</b> ! Un biscuit premier
                         prix est <b>4 fois moins gras</b> qu'un yaourt et <b>5 fois moins sucré</b>. De plus, il faut boire <b>2 verres de jus d'orange
                         premier prix</b> pour consommer <b>autant de sucres</b> que dans une cuillère à café de pâte à tartiner ou dans un yaourt.
-                        </p>       
+                        </p>
                 </div>
-                
+
                 </div>
                 </div>
 
@@ -370,7 +370,7 @@
 					</footer>
 				</div>
 			</section>
-            
+
 		<!-- Comparaison internationale -->
 			<section id="world" class="wrapper style2 align-center">
 				<div class="container">

--- a/js/scripts.js
+++ b/js/scripts.js
@@ -62,9 +62,23 @@ nv.addGraph(function() {
   nv.utils.windowResize(chart.update);
 
   return chart;});
-  
+
   });
-  
-    
+
+
 }
 
+$( document ).ready(function() {
+  $('#compare-tabs a').click(function(e) {
+    e.preventDefault();
+    // Show the tab
+    paneID = $(e.target).attr('href');
+    $(this).tab('show');
+    // If the iframe hasn't already been loaded once
+    console.log($(paneID+' iframe').attr('src'))
+    if(! $(paneID+' iframe').attr('src')) {
+      // Load it!
+      $(paneID+' iframe').attr('src', $(paneID+' iframe').attr('data-src'));
+    }
+  });
+});


### PR DESCRIPTION
An egde case provoked the iframe not to be displayed on tabs selection.
Loading the iframe just when a tab is selected ensure it's height is correctly set, fixes the problem!

Found the solution by searching https://www.google.fr/webhp?sourceid=chrome-instant&ion=1&espv=2&ie=UTF-8#q=bootstrap%20iframe%20tabs and adapting to your case.
